### PR TITLE
Fix socket disconnect error reported by mosquitto

### DIFF
--- a/led_status_helper/src/main.rs
+++ b/led_status_helper/src/main.rs
@@ -157,9 +157,7 @@ fn main() {
         MqttClient::start(opts, None).expect("MQTT client couldn't start")
     };
 
-    let mut last_publish = std::time::SystemTime::now();
     loop {
-        if last_publish.elapsed().unwrap().as_secs() > 10 {
             let status = generate_status(
                 &redis_conn,
                 &config.temp_unit.unwrap_or('F'),
@@ -172,7 +170,6 @@ fn main() {
                     status.unwrap().clone().into_bytes(),
                 )
                 .unwrap();
-            last_publish = std::time::SystemTime::now();
-        }
+            std::thread::sleep(std::time::Duration::from_millis(13000));
     }
 }

--- a/led_status_helper/src/main.rs
+++ b/led_status_helper/src/main.rs
@@ -22,6 +22,7 @@ struct Config {
     mqtt_port: Option<u16>,
     mqtt_topic: String,
     temp_unit: Option<char>,
+    wait_secs: Option<u64>,
 }
 
 fn generate_mq_client_id() -> String {
@@ -157,6 +158,8 @@ fn main() {
         MqttClient::start(opts, None).expect("MQTT client couldn't start")
     };
 
+    let wait_secs = config.wait_secs.unwrap_or(10);
+
     loop {
         let status = generate_status(
             &redis_conn,
@@ -170,6 +173,6 @@ fn main() {
                 status.unwrap().clone().into_bytes(),
             )
             .unwrap();
-        std::thread::sleep(std::time::Duration::from_millis(13000));
+        std::thread::sleep(std::time::Duration::from_secs(wait_secs));
     }
 }

--- a/led_status_helper/src/main.rs
+++ b/led_status_helper/src/main.rs
@@ -158,18 +158,18 @@ fn main() {
     };
 
     loop {
-            let status = generate_status(
-                &redis_conn,
-                &config.temp_unit.unwrap_or('F'),
-                &config.redis_namespace.clone().unwrap_or("".to_string()),
-            );
-            mq_cli
-                .publish(
-                    &config.mqtt_topic,
-                    QoS::Level0,
-                    status.unwrap().clone().into_bytes(),
-                )
-                .unwrap();
-            std::thread::sleep(std::time::Duration::from_millis(13000));
+        let status = generate_status(
+            &redis_conn,
+            &config.temp_unit.unwrap_or('F'),
+            &config.redis_namespace.clone().unwrap_or("".to_string()),
+        );
+        mq_cli
+            .publish(
+                &config.mqtt_topic,
+                QoS::Level0,
+                status.unwrap().clone().into_bytes(),
+            )
+            .unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(13000));
     }
 }


### PR DESCRIPTION
LED status helper had been causing socket disconnect errors in the mosquitto logs.  See issue #11.

This PR removes the socket disconnect errors by running the status updates in a loop.