### PR TITLE
Implement basic ability to push via google pubsub

### DIFF
--- a/services/gcloud_push/Cargo.lock
+++ b/services/gcloud_push/Cargo.lock
@@ -244,7 +244,7 @@ dependencies = [
  "hyper-native-tls 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "redis 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "redis_context 0.1.0",
- "redis_delta 0.1.0",
+ "redis_delta 0.1.1",
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -684,7 +684,7 @@ dependencies = [
 
 [[package]]
 name = "redis_delta"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/services/gcloud_push/Cargo.lock
+++ b/services/gcloud_push/Cargo.lock
@@ -209,10 +209,15 @@ dependencies = [
  "dotenv 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "envy 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "google-pubsub1_beta2 1.0.8+20181001 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.10.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper-rustls 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "redis 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "redis_context 0.1.0",
  "redis_delta 0.1.0",
+ "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "yup-oauth2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -260,6 +265,17 @@ dependencies = [
  "antidote 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.10.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "native-tls 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "hyper 0.10.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustls 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "webpki 0.18.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "webpki-roots 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -648,6 +664,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "untrusted 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -663,6 +690,19 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rustls"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ring 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sct 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "untrusted 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "webpki 0.18.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -688,6 +728,15 @@ dependencies = [
 name = "scopeguard"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "sct"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ring 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "untrusted 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "security-framework"
@@ -938,6 +987,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "untrusted"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "url"
 version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -996,6 +1050,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "webpki"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ring 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "untrusted 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "untrusted 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "webpki 0.18.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "winapi"
@@ -1085,6 +1157,7 @@ dependencies = [
 "checksum httparse 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e8734b0cfd3bc3e101ec59100e101c2eecd19282202e87808b3037b442777a83"
 "checksum hyper 0.10.15 (registry+https://github.com/rust-lang/crates.io-index)" = "df0caae6b71d266b91b4a83111a61d2b94ed2e2bea024c532b933dcff867e58c"
 "checksum hyper-native-tls 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6d375598f442742b0e66208ee12501391f1c7ac0bafb90b4fe53018f81f06068"
+"checksum hyper-rustls 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "71f7b2e5858ab9e19771dc361159f09ee5031734a6f7471fe0947db0238d92b7"
 "checksum idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
 "checksum iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"
 "checksum itertools 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)" = "f58856976b776fedd95533137617a02fb25719f40e7d9b01c7043cd65474f450"
@@ -1127,13 +1200,16 @@ dependencies = [
 "checksum regex 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "2069749032ea3ec200ca51e4a31df41759190a88edca0d2d86ee8bedf7073341"
 "checksum regex-syntax 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "747ba3b235651f6e2f67dfa8bcdcd073ddb7c243cb21c442fc12395dfcac212d"
 "checksum remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5"
+"checksum ring 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe642b9dd1ba0038d78c4a3999d1ee56178b4d415c1e1fbaba83b06dce012f0"
 "checksum rustc-demangle 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "bcfe5b13211b4d78e5c2cadfebd7769197d95c639c35a50057eb4c05de811395"
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
+"checksum rustls 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)" = "942b71057b31981152970d57399c25f72e27a6ee0d207a669d8304cabf44705b"
 "checksum ryu 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7153dd96dade874ab973e098cb62fcdbb89a03682e46b144fd09550998d4a4a7"
 "checksum safemem 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8dca453248a96cb0749e36ccdfe2b0b4e54a61bfef89fb97ec621eb8e0a93dd9"
 "checksum schannel 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "0e1a231dc10abf6749cfa5d7767f25888d484201accbd919b66ab5413c502d56"
 "checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
+"checksum sct 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cb8f61f9e6eadd062a71c380043d28036304a4706b3c4dd001ff3387ed00745a"
 "checksum security-framework 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "697d3f3c23a618272ead9e1fb259c1411102b31c6af8b93f1d64cca9c3b0e8e0"
 "checksum security-framework-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ab01dfbe5756785b5b4d46e0289e5a18071dfa9a7c2b24213ea00b9ef9b665bf"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
@@ -1164,6 +1240,7 @@ dependencies = [
 "checksum unicode-normalization 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "6a0180bc61fc5a987082bfa111f4cc95c4caff7f9799f3e46df09163a937aa25"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
+"checksum untrusted 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "55cd1f4b4e96b46aeb8d4855db4a7a9bd96eeeb5c6a1ab54593328761642ce2f"
 "checksum url 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4a3440c1ed62af4a2aee71c6fb78ef32ddcb75cfa24bf42f45e07c02b6d6a2f6"
 "checksum url 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2a321979c09843d272956e73700d12c4e7d3d92b2ee112b31548aef0d4efc5a6"
 "checksum utf8-ranges 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "796f7e48bef87609f7ade7e06495a87d5cd06c7866e6a5cbfceffc558a243737"
@@ -1172,6 +1249,8 @@ dependencies = [
 "checksum vcpkg 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "def296d3eb3b12371b2c7d0e83bfe1403e4db2d7a0bba324a12b21c4ee13143d"
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+"checksum webpki 0.18.1 (registry+https://github.com/rust-lang/crates.io-index)" = "17d7967316d8411ca3b01821ee6c332bde138ba4363becdb492f12e514daa17f"
+"checksum webpki-roots 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)" = "85d1f408918fd590908a70d36b7ac388db2edc221470333e4d6e5b598e44cabf"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "92c1eb33641e276cfa214a0522acad57be5c56b10cb348b3c5117db75f3ac4b0"
 "checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"

--- a/services/gcloud_push/Cargo.lock
+++ b/services/gcloud_push/Cargo.lock
@@ -39,16 +39,19 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "base64"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "safemem 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "base64"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -233,7 +236,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "gcloud_push"
 version = "0.1.0"
 dependencies = [
- "base64 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "base64 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "dotenv 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "envy 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "google-pubsub1 1.0.8+20181001 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1163,7 +1166,7 @@ dependencies = [
 "checksum ascii 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3ae7d751998c189c1d4468cf0a39bb2eae052a9c58d50ebb3b9591ee3813ad50"
 "checksum backtrace 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "89a47830402e9981c5c41223151efcced65a0510c13097c769cede7efb34782a"
 "checksum backtrace-sys 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)" = "c66d56ac8dabd07f6aacdaf633f4b8262f5b3601a810a0dcddffd5c22c69daa0"
-"checksum base64 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2015e3793554aa5b6007e3a72959e84c1070039e74f13dde08fa64afe1ddd892"
+"checksum base64 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "621fc7ecb8008f86d7fb9b95356cd692ce9514b80a86d85b397f32a22da7b9e2"
 "checksum base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "489d6c0ed21b11d038c31b6ceccca973e65d73ba3bd8ecb9a2babf5546164643"
 "checksum bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4efd02e230a02e18f92fc2735f44597385ed02ad8f831e7c1c1156ee5e1ab3a5"
 "checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"

--- a/services/gcloud_push/Cargo.lock
+++ b/services/gcloud_push/Cargo.lock
@@ -215,6 +215,7 @@ dependencies = [
  "redis_context 0.1.0",
  "redis_delta 0.1.0",
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "yup-oauth2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/services/gcloud_push/Cargo.lock
+++ b/services/gcloud_push/Cargo.lock
@@ -208,9 +208,9 @@ version = "0.1.0"
 dependencies = [
  "dotenv 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "envy 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "google-pubsub1_beta2 1.0.8+20181001 (registry+https://github.com/rust-lang/crates.io-index)",
+ "google-pubsub1 1.0.8+20181001 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.10.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper-rustls 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper-native-tls 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "redis 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "redis_context 0.1.0",
  "redis_delta 0.1.0",
@@ -222,7 +222,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "google-pubsub1_beta2"
+name = "google-pubsub1"
 version = "1.0.8+20181001"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -266,17 +266,6 @@ dependencies = [
  "antidote 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.10.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "native-tls 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "hyper-rustls"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "hyper 0.10.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustls 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "webpki 0.18.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "webpki-roots 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -665,17 +654,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ring"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "cc 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "untrusted 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "rustc-demangle"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -691,19 +669,6 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "rustls"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "ring 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sct 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "untrusted 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "webpki 0.18.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -729,15 +694,6 @@ dependencies = [
 name = "scopeguard"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "sct"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "ring 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "untrusted 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "security-framework"
@@ -988,11 +944,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "untrusted"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "url"
 version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1051,24 +1002,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "webpki"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "ring 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "untrusted 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "untrusted 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "webpki 0.18.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "winapi"
@@ -1154,11 +1087,10 @@ dependencies = [
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 "checksum futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)" = "49e7653e374fe0d0c12de4250f0bdb60680b8c80eed558c5c7538eec9c89e21b"
-"checksum google-pubsub1_beta2 1.0.8+20181001 (registry+https://github.com/rust-lang/crates.io-index)" = "36cd3093b6f1c50859283293d57f993e3b01658b5cbbe659501083354655bfde"
+"checksum google-pubsub1 1.0.8+20181001 (registry+https://github.com/rust-lang/crates.io-index)" = "87c4bd8871ca2f700519861760bbbd639ccf4b4f33bae20d905c357542368ffa"
 "checksum httparse 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e8734b0cfd3bc3e101ec59100e101c2eecd19282202e87808b3037b442777a83"
 "checksum hyper 0.10.15 (registry+https://github.com/rust-lang/crates.io-index)" = "df0caae6b71d266b91b4a83111a61d2b94ed2e2bea024c532b933dcff867e58c"
 "checksum hyper-native-tls 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6d375598f442742b0e66208ee12501391f1c7ac0bafb90b4fe53018f81f06068"
-"checksum hyper-rustls 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "71f7b2e5858ab9e19771dc361159f09ee5031734a6f7471fe0947db0238d92b7"
 "checksum idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
 "checksum iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"
 "checksum itertools 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)" = "f58856976b776fedd95533137617a02fb25719f40e7d9b01c7043cd65474f450"
@@ -1201,16 +1133,13 @@ dependencies = [
 "checksum regex 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "2069749032ea3ec200ca51e4a31df41759190a88edca0d2d86ee8bedf7073341"
 "checksum regex-syntax 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "747ba3b235651f6e2f67dfa8bcdcd073ddb7c243cb21c442fc12395dfcac212d"
 "checksum remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5"
-"checksum ring 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe642b9dd1ba0038d78c4a3999d1ee56178b4d415c1e1fbaba83b06dce012f0"
 "checksum rustc-demangle 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "bcfe5b13211b4d78e5c2cadfebd7769197d95c639c35a50057eb4c05de811395"
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
-"checksum rustls 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)" = "942b71057b31981152970d57399c25f72e27a6ee0d207a669d8304cabf44705b"
 "checksum ryu 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7153dd96dade874ab973e098cb62fcdbb89a03682e46b144fd09550998d4a4a7"
 "checksum safemem 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8dca453248a96cb0749e36ccdfe2b0b4e54a61bfef89fb97ec621eb8e0a93dd9"
 "checksum schannel 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "0e1a231dc10abf6749cfa5d7767f25888d484201accbd919b66ab5413c502d56"
 "checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
-"checksum sct 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cb8f61f9e6eadd062a71c380043d28036304a4706b3c4dd001ff3387ed00745a"
 "checksum security-framework 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "697d3f3c23a618272ead9e1fb259c1411102b31c6af8b93f1d64cca9c3b0e8e0"
 "checksum security-framework-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ab01dfbe5756785b5b4d46e0289e5a18071dfa9a7c2b24213ea00b9ef9b665bf"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
@@ -1241,7 +1170,6 @@ dependencies = [
 "checksum unicode-normalization 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "6a0180bc61fc5a987082bfa111f4cc95c4caff7f9799f3e46df09163a937aa25"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
-"checksum untrusted 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "55cd1f4b4e96b46aeb8d4855db4a7a9bd96eeeb5c6a1ab54593328761642ce2f"
 "checksum url 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4a3440c1ed62af4a2aee71c6fb78ef32ddcb75cfa24bf42f45e07c02b6d6a2f6"
 "checksum url 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2a321979c09843d272956e73700d12c4e7d3d92b2ee112b31548aef0d4efc5a6"
 "checksum utf8-ranges 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "796f7e48bef87609f7ade7e06495a87d5cd06c7866e6a5cbfceffc558a243737"
@@ -1250,8 +1178,6 @@ dependencies = [
 "checksum vcpkg 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "def296d3eb3b12371b2c7d0e83bfe1403e4db2d7a0bba324a12b21c4ee13143d"
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
-"checksum webpki 0.18.1 (registry+https://github.com/rust-lang/crates.io-index)" = "17d7967316d8411ca3b01821ee6c332bde138ba4363becdb492f12e514daa17f"
-"checksum webpki-roots 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)" = "85d1f408918fd590908a70d36b7ac388db2edc221470333e4d6e5b598e44cabf"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "92c1eb33641e276cfa214a0522acad57be5c56b10cb348b3c5117db75f3ac4b0"
 "checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"

--- a/services/gcloud_push/Cargo.lock
+++ b/services/gcloud_push/Cargo.lock
@@ -39,6 +39,11 @@ dependencies = [
 
 [[package]]
 name = "base64"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "base64"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -228,6 +233,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "gcloud_push"
 version = "0.1.0"
 dependencies = [
+ "base64 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "dotenv 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "envy 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "google-pubsub1 1.0.8+20181001 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1157,6 +1163,7 @@ dependencies = [
 "checksum ascii 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3ae7d751998c189c1d4468cf0a39bb2eae052a9c58d50ebb3b9591ee3813ad50"
 "checksum backtrace 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "89a47830402e9981c5c41223151efcced65a0510c13097c769cede7efb34782a"
 "checksum backtrace-sys 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)" = "c66d56ac8dabd07f6aacdaf633f4b8262f5b3601a810a0dcddffd5c22c69daa0"
+"checksum base64 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2015e3793554aa5b6007e3a72959e84c1070039e74f13dde08fa64afe1ddd892"
 "checksum base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "489d6c0ed21b11d038c31b6ceccca973e65d73ba3bd8ecb9a2babf5546164643"
 "checksum bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4efd02e230a02e18f92fc2735f44597385ed02ad8f831e7c1c1156ee5e1ab3a5"
 "checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"

--- a/services/gcloud_push/Cargo.lock
+++ b/services/gcloud_push/Cargo.lock
@@ -48,6 +48,11 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "bitflags"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
@@ -107,10 +112,27 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "core-foundation-sys 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "core-foundation"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "core-foundation-sys 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -210,7 +232,7 @@ dependencies = [
  "envy 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "google-pubsub1 1.0.8+20181001 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.10.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper-native-tls 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper-native-tls 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "redis 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "redis_context 0.1.0",
  "redis_delta 0.1.0",
@@ -256,6 +278,16 @@ dependencies = [
  "typeable 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicase 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "hyper-native-tls"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "antidote 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.10.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "native-tls 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -312,6 +344,11 @@ dependencies = [
 [[package]]
 name = "language-tags"
 version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "lazy_static"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -411,6 +448,20 @@ dependencies = [
 
 [[package]]
 name = "native-tls"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl 0.9.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "schannel 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "security-framework 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "security-framework-sys 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "native-tls"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -455,6 +506,18 @@ version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "openssl"
+version = "0.9.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.9.39 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -697,6 +760,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "security-framework"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "core-foundation 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-foundation-sys 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "security-framework-sys 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "security-framework"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -704,6 +778,15 @@ dependencies = [
  "core-foundation-sys 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "security-framework-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "core-foundation-sys 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -795,6 +878,15 @@ dependencies = [
  "quote 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.15.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tempdir"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1066,6 +1158,7 @@ dependencies = [
 "checksum backtrace 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "89a47830402e9981c5c41223151efcced65a0510c13097c769cede7efb34782a"
 "checksum backtrace-sys 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)" = "c66d56ac8dabd07f6aacdaf633f4b8262f5b3601a810a0dcddffd5c22c69daa0"
 "checksum base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "489d6c0ed21b11d038c31b6ceccca973e65d73ba3bd8ecb9a2babf5546164643"
+"checksum bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4efd02e230a02e18f92fc2735f44597385ed02ad8f831e7c1c1156ee5e1ab3a5"
 "checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
 "checksum byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "94f88df23a25417badc922ab0f5716cc1330e87f71ddd9203b3a3ccd9cedf75d"
 "checksum bytes 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "0ce55bd354b095246fc34caf4e9e242f5297a7fd938b090cadfea6eee614aa62"
@@ -1074,7 +1167,9 @@ dependencies = [
 "checksum chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "45912881121cb26fad7c38c17ba7daa18764771836b34fab7d3fbd93ed633878"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum combine 3.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fc1d011beeed29187b8db2ac3925c8dd4d3e87db463dc9d2d2833985388fc5bc"
+"checksum core-foundation 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "25bfd746d203017f7d5cbd31ee5d8e17f94b6521c7af77ece6c9e4b2d4b16c67"
 "checksum core-foundation 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "286e0b41c3a20da26536c6000a280585d519fd07b3956b43aed8a79e9edce980"
+"checksum core-foundation-sys 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "065a5d7ffdcbc8fa145d6f0746f3555025b9097a9e9cda59f7467abae670c78d"
 "checksum core-foundation-sys 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "716c271e8613ace48344f723b60b900a93150271e5be206212d052bbc0883efa"
 "checksum crossbeam-utils 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "677d453a17e8bd2b913fa38e8b9cf04bcdbb5be790aa294f2389661d72036015"
 "checksum dotenv 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c0d0a1279c96732bc6800ce6337b6a614697b0e74ae058dc03c62ebeb78b4d86"
@@ -1090,6 +1185,7 @@ dependencies = [
 "checksum google-pubsub1 1.0.8+20181001 (registry+https://github.com/rust-lang/crates.io-index)" = "87c4bd8871ca2f700519861760bbbd639ccf4b4f33bae20d905c357542368ffa"
 "checksum httparse 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e8734b0cfd3bc3e101ec59100e101c2eecd19282202e87808b3037b442777a83"
 "checksum hyper 0.10.15 (registry+https://github.com/rust-lang/crates.io-index)" = "df0caae6b71d266b91b4a83111a61d2b94ed2e2bea024c532b933dcff867e58c"
+"checksum hyper-native-tls 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "72332e4a35d3059583623b50e98e491b78f8b96c5521fcb3f428167955aa56e8"
 "checksum hyper-native-tls 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6d375598f442742b0e66208ee12501391f1c7ac0bafb90b4fe53018f81f06068"
 "checksum idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
 "checksum iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"
@@ -1097,6 +1193,7 @@ dependencies = [
 "checksum itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1306f3464951f30e30d12373d31c79fbd52d236e5e896fd92f96ec7babbbe60b"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
+"checksum lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
 "checksum lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ca488b89a5657b0a2ecd45b95609b3e848cf1755da332a0da46e2b2b1cb371a7"
 "checksum lazycell 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ddba4c30a78328befecec92fc94970e53b3ae385827d28620f0f5bb2493081e0"
 "checksum libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)" = "76e3a3ef172f1a0b9a9ff0dd1491ae5e6c948b94479a3021819ba7d860c8645d"
@@ -1108,12 +1205,14 @@ dependencies = [
 "checksum mime 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ba626b8a6de5da682e1caa06bdb42a335aee5a84db8e5046a3e8ab17ba0a3ae0"
 "checksum mio 0.6.16 (registry+https://github.com/rust-lang/crates.io-index)" = "71646331f2619b1026cc302f87a2b8b648d5c6dd6937846a16cc8ce0f347f432"
 "checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
+"checksum native-tls 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "f74dbadc8b43df7864539cedb7bc91345e532fdd913cfdc23ad94f4d2d40fbc0"
 "checksum native-tls 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ff8e08de0070bbf4c31f452ea2a70db092f36f6f2e4d897adf5674477d488fb2"
 "checksum net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88"
 "checksum num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "e83d528d2677f0518c570baf2b7abdcf0cd2d248860b68507bdcb3e91d4c0cea"
 "checksum num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0b3a5d7cc97d6d30d8b9bc8fa19bf45349ffe46241e8816f50f62f6d6aaabee1"
 "checksum num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c51a3322e4bca9d212ad9a158a02abc6934d005490c054a2778df73a70aa0a30"
 "checksum openssl 0.10.15 (registry+https://github.com/rust-lang/crates.io-index)" = "5e1309181cdcbdb51bc3b6bedb33dfac2a83b3d585033d3f6d9e22e8c1928613"
+"checksum openssl 0.9.24 (registry+https://github.com/rust-lang/crates.io-index)" = "a3605c298474a3aa69de92d21139fb5e2a81688d308262359d85cdd0d12a7985"
 "checksum openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 "checksum openssl-sys 0.9.39 (registry+https://github.com/rust-lang/crates.io-index)" = "278c1ad40a89aa1e741a1eed089a2f60b18fab8089c3139b542140fc7d674106"
 "checksum owning_ref 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "cdf84f41639e037b484f93433aa3897863b561ed65c6e59c7073d7c561710f37"
@@ -1140,7 +1239,9 @@ dependencies = [
 "checksum safemem 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8dca453248a96cb0749e36ccdfe2b0b4e54a61bfef89fb97ec621eb8e0a93dd9"
 "checksum schannel 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "0e1a231dc10abf6749cfa5d7767f25888d484201accbd919b66ab5413c502d56"
 "checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
+"checksum security-framework 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "dfa44ee9c54ce5eecc9de7d5acbad112ee58755239381f687e564004ba4a2332"
 "checksum security-framework 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "697d3f3c23a618272ead9e1fb259c1411102b31c6af8b93f1d64cca9c3b0e8e0"
+"checksum security-framework-sys 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "5421621e836278a0b139268f36eee0dc7e389b784dc3f79d8f11aabadf41bead"
 "checksum security-framework-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ab01dfbe5756785b5b4d46e0289e5a18071dfa9a7c2b24213ea00b9ef9b665bf"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
@@ -1153,6 +1254,7 @@ dependencies = [
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 "checksum syn 0.15.18 (registry+https://github.com/rust-lang/crates.io-index)" = "90c39a061e2f412a9f869540471ab679e85e50c6b05604daf28bc3060f75c430"
 "checksum synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "73687139bf99285483c96ac0add482c3776528beac1d97d444f6e91f203a2015"
+"checksum tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
 "checksum tempfile 3.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "55c1195ef8513f3273d55ff59fe5da6940287a0d7a98331254397f464833675b"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
 "checksum time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "d825be0eb33fda1a7e68012d51e9c7f451dc1a69391e7fdc197060bb8c56667b"

--- a/services/gcloud_push/Cargo.toml
+++ b/services/gcloud_push/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Terkwood <metaterkhorn@gmail.com>"]
 edition = "2018"
 
 [dependencies]
-base64 = "0.2"
+base64 = "0.10"
 dotenv = "0.13"
 envy = "0.3"
 redis = "0.9"
@@ -16,7 +16,8 @@ serde_derive = "^1.0"
 serde_json = "^1.0"
 uuid = { version = "0.7", features = ["v4", "v5", "serde"] }
 
-yup-oauth2 = "^ 1.0"
-google-pubsub1 = "^ 1.0"
+# we need a specific version of hyper
+yup-oauth2 = "^1.0"
+google-pubsub1 = "^1.0"
 hyper = "0.10"
 hyper-native-tls = "0.2"

--- a/services/gcloud_push/Cargo.toml
+++ b/services/gcloud_push/Cargo.toml
@@ -6,9 +6,17 @@ edition = "2018"
 
 [dependencies]
 dotenv = "0.13"
-google-pubsub1_beta2 = "1.0.8+20181001"
+google-pubsub1_beta2 = "*"
+# Google cloud projects intentionally use an old version of Hyper.
+# See https://github.com/Byron/google-apis-rs/issues/173 for more
+# information.
+hyper = "^0.10"
+hyper-rustls = "^0.6"
 envy = "0.3"
 redis = "0.9"
 redis_context = { path = "../redis_context" }
 redis_delta = { path = "../redis_delta" }
+serde = "^1.0"
+serde_json = "^1.0"
 uuid = { version = "0.7", features = ["v4", "v5", "serde"] }
+yup-oauth2 = "^1.0"

--- a/services/gcloud_push/Cargo.toml
+++ b/services/gcloud_push/Cargo.toml
@@ -6,13 +6,6 @@ edition = "2018"
 
 [dependencies]
 dotenv = "0.13"
-google-pubsub1 = "^1.0"
-# Specific version of hyper and hyper-native-TLS required
-# in order to make "service account" authentication work,
-# and generally in order to make the rust APIs for GCP 
-# work.
-hyper = "0.10.2"
-hyper-native-tls = "0.3"
 envy = "0.3"
 redis = "0.9"
 redis_context = { path = "../redis_context" }
@@ -21,4 +14,8 @@ serde = "^1.0"
 serde_derive = "^1.0"
 serde_json = "^1.0"
 uuid = { version = "0.7", features = ["v4", "v5", "serde"] }
-yup-oauth2 = "^1.0"
+
+yup-oauth2 = "^ 1.0"
+google-pubsub1 = "^ 1.0"
+hyper = "0.10"
+hyper-native-tls = "0.2"

--- a/services/gcloud_push/Cargo.toml
+++ b/services/gcloud_push/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Terkwood <metaterkhorn@gmail.com>"]
 edition = "2018"
 
 [dependencies]
+base64 = "0.2"
 dotenv = "0.13"
 envy = "0.3"
 redis = "0.9"

--- a/services/gcloud_push/Cargo.toml
+++ b/services/gcloud_push/Cargo.toml
@@ -6,12 +6,13 @@ edition = "2018"
 
 [dependencies]
 dotenv = "0.13"
-google-pubsub1_beta2 = "*"
-# Google cloud projects intentionally use an old version of Hyper.
-# See https://github.com/Byron/google-apis-rs/issues/173 for more
-# information.
-hyper = "^0.10"
-hyper-rustls = "^0.6"
+google-pubsub1 = "^1.0"
+# Specific version of hyper and hyper-native-TLS required
+# in order to make "service account" authentication work,
+# and generally in order to make the rust APIs for GCP 
+# work.
+hyper = "0.10.2"
+hyper-native-tls = "0.3"
 envy = "0.3"
 redis = "0.9"
 redis_context = { path = "../redis_context" }

--- a/services/gcloud_push/Cargo.toml
+++ b/services/gcloud_push/Cargo.toml
@@ -17,6 +17,7 @@ redis = "0.9"
 redis_context = { path = "../redis_context" }
 redis_delta = { path = "../redis_delta" }
 serde = "^1.0"
+serde_derive = "^1.0"
 serde_json = "^1.0"
 uuid = { version = "0.7", features = ["v4", "v5", "serde"] }
 yup-oauth2 = "^1.0"

--- a/services/gcloud_push/Cargo.toml
+++ b/services/gcloud_push/Cargo.toml
@@ -16,7 +16,8 @@ serde_derive = "^1.0"
 serde_json = "^1.0"
 uuid = { version = "0.7", features = ["v4", "v5", "serde"] }
 
-# we need a specific version of hyper
+# we need a specific version of hyper, for the google pubsub bindings
+# to work
 yup-oauth2 = "^1.0"
 google-pubsub1 = "^1.0"
 hyper = "0.10"

--- a/services/gcloud_push/src/config.rs
+++ b/services/gcloud_push/src/config.rs
@@ -1,0 +1,78 @@
+use hyper::net::HttpsConnector;
+use redis_context::RedisContext;
+use redis_delta::RDelta;
+use yup_oauth2::GetToken;
+
+use crate::model::{PubSubClient, PubSubContext};
+use hyper_native_tls::NativeTlsClient;
+use std::default::Default;
+
+#[derive(Deserialize, Serialize, Debug)]
+pub struct PubSubConfig {
+    pub pubsub_project_id: Option<String>,
+    pub pubsub_topic_name: Option<String>,
+    pub pubsub_secret_file: Option<String>,
+    pub redis_auth: Option<String>,
+    pub redis_host: Option<String>,
+    pub redis_port: Option<u16>,
+    pub redis_namespace: Option<String>,
+}
+
+impl PubSubConfig {
+    pub fn new() -> PubSubConfig {
+        match envy::from_env::<PubSubConfig>() {
+            Ok(config) => config,
+            Err(e) => panic!("Unable to parse config ({})", e),
+        }
+    }
+
+    /// Create an object which holds both a connection to redis
+    /// and a string "namespace" used to prefix all keys.
+    pub fn to_redis_context(&self) -> RedisContext {
+        RedisContext::new(
+            (self.redis_host.clone().unwrap_or("127.0.0.1".to_string())).to_string(),
+            self.redis_port.unwrap_or(6379),
+            self.redis_auth.clone(),
+            self.redis_namespace.clone().unwrap_or("".to_string()),
+        )
+    }
+
+    /// Create a client used to publish to google pub/sub.
+    /// See instructions at https://docs.rs/google-pubsub1_beta2/1.0.8+20181001/google_pubsub1_beta2/
+    pub fn to_pubsub_client(&self) -> PubSubClient {
+        let secret_file = self
+            .pubsub_secret_file
+            .clone()
+            .unwrap_or("secret.json".to_string());
+        let client_secret =
+            yup_oauth2::service_account_key_from_file(&"pubsub-auth.json".to_string()).unwrap();
+        let client =
+            hyper::Client::with_connector(HttpsConnector::new(NativeTlsClient::new().unwrap()));
+        let mut access = yup_oauth2::ServiceAccountAccess::new(client_secret, client);
+
+        println!(
+            "{:?}",
+            access
+                .token(&vec!["https://www.googleapis.com/auth/pubsub"])
+                .unwrap()
+        );
+
+        let client =
+            hyper::Client::with_connector(HttpsConnector::new(NativeTlsClient::new().unwrap()));
+        google_pubsub1::Pubsub::new(client, access)
+    }
+
+    pub fn to_pubsub_context(&self) -> PubSubContext {
+        let project_id = self
+            .pubsub_project_id
+            .clone()
+            .unwrap_or("project".to_string());
+        let topic_name = self
+            .pubsub_topic_name
+            .clone()
+            .unwrap_or("topic".to_string());
+        let fq_topic = format!("projects/{}/topics/{}", project_id, topic_name);
+        let client = self.to_pubsub_client();
+        PubSubContext { fq_topic, client }
+    }
+}

--- a/services/gcloud_push/src/config.rs
+++ b/services/gcloud_push/src/config.rs
@@ -1,11 +1,9 @@
 use hyper::net::HttpsConnector;
 use redis_context::RedisContext;
-use redis_delta::RDelta;
 use yup_oauth2::GetToken;
 
 use crate::model::{PubSubClient, PubSubContext};
 use hyper_native_tls::NativeTlsClient;
-use std::default::Default;
 
 #[derive(Deserialize, Serialize, Debug)]
 pub struct PubSubConfig {
@@ -43,9 +41,9 @@ impl PubSubConfig {
         let secret_file = self
             .pubsub_secret_file
             .clone()
-            .unwrap_or("secret.json".to_string());
-        let client_secret =
-            yup_oauth2::service_account_key_from_file(&"pubsub-auth.json".to_string()).unwrap();
+            .unwrap_or("secret.json".to_string())
+            .to_string();
+        let client_secret = yup_oauth2::service_account_key_from_file(&secret_file).unwrap();
         let client =
             hyper::Client::with_connector(HttpsConnector::new(NativeTlsClient::new().unwrap()));
         let mut access = yup_oauth2::ServiceAccountAccess::new(client_secret, client);

--- a/services/gcloud_push/src/lib.rs
+++ b/services/gcloud_push/src/lib.rs
@@ -70,7 +70,7 @@ pub fn clone_the_world(_redis_ctx: &RedisContext, _pubsub_ctx: &PubSubContext) {
 ///   entire set, or the string itself.
 /// - For hash field updates, we only retrieve the fields
 ///   which have been updated.
-pub fn push_recent<E>(
+pub fn push_recent(
     redis_ctx: &RedisContext,
     pubsub_ctx: &PubSubContext,
     redis_events: Vec<REvent>,

--- a/services/gcloud_push/src/lib.rs
+++ b/services/gcloud_push/src/lib.rs
@@ -18,7 +18,7 @@ mod model;
 use base64;
 use redis::Commands;
 use redis_context::RedisContext;
-use redis_delta::{RDelta, REvent};
+use redis_delta::{RDelta, REvent, RField};
 
 use self::model::{PubSubClient, PubSubContext};
 use self::pubsub::PublishRequest;
@@ -122,7 +122,11 @@ fn fetch_hash_delta<'a, 'b>(
     fields: Vec<String>,
     ctx: &RedisContext,
 ) -> Result<RDelta<'a, 'b>, redis::RedisError> {
+    let fields_forever = fields.clone();
     let found: Vec<Option<String>> = ctx.conn.hget(key, fields)?;
+    let zipped = fields_forever.iter().zip(found);
+    let rfields = zipped.map(|(f, maybe_v)| maybe_v.map(|v| RField { name: f, val: v }));
+
     Ok(RDelta::UpdateHash {
         key,
         fields: unimplemented!(),

--- a/services/gcloud_push/src/lib.rs
+++ b/services/gcloud_push/src/lib.rs
@@ -18,7 +18,7 @@ mod model;
 use base64;
 
 use redis_context::RedisContext;
-use redis_delta::RDeltaEvent;
+use redis_delta::REvent;
 
 use self::model::{PubSubClient, PubSubContext};
 use self::pubsub::PublishRequest;
@@ -62,10 +62,13 @@ pub fn clone_the_world(_redis_ctx: &RedisContext, _pubsub_ctx: &PubSubContext) {
 
 /// Publish a vec of redis changes (hash updates, string updates, etc)
 /// to google pubsub system.
+/// 
+/// In order to get this done, we need to first retrieve a recent
+/// copy of each piece of data referred to in the RDelta
 pub fn push_recent<E>(
     _redis_context: &RedisContext,
     _pubsub: &PubSubClient,
-    _rdeltas: Vec<RDeltaEvent>,
+    _redis_events: Vec<RDeltaEvent>,
 ) -> Result<(), E> {
     unimplemented!()
 }

--- a/services/gcloud_push/src/lib.rs
+++ b/services/gcloud_push/src/lib.rs
@@ -68,7 +68,7 @@ pub fn clone_the_world(_redis_ctx: &RedisContext, _pubsub_ctx: &PubSubContext) {
 pub fn push_recent<E>(
     _redis_context: &RedisContext,
     _pubsub: &PubSubClient,
-    _redis_events: Vec<RDeltaEvent>,
+    _redis_events: Vec<REvent>,
 ) -> Result<(), E> {
     unimplemented!()
 }

--- a/services/gcloud_push/src/lib.rs
+++ b/services/gcloud_push/src/lib.rs
@@ -151,8 +151,10 @@ fn fetch_hash_delta<'a>(
 
 fn push(data: &RDelta, pubsub_ctx: &PubSubContext) -> Result<(), pubsub::Error> {
     let message = google_pubsub1::PubsubMessage {
-        // Base64 encoded!
-        data: Some(base64::encode("HELLO ANYONE!".as_bytes())),
+        // This must be base64 encoded!
+        data: Some(base64::encode(
+            serde_json::to_string(data).unwrap().as_bytes(),
+        )),
         ..Default::default()
     };
 
@@ -160,7 +162,6 @@ fn push(data: &RDelta, pubsub_ctx: &PubSubContext) -> Result<(), pubsub::Error> 
         messages: Some(vec![message]),
     };
 
-    println!("Publishing to {}", &pubsub_ctx.fq_topic);
     pubsub_ctx
         .client
         .projects()

--- a/services/gcloud_push/src/lib.rs
+++ b/services/gcloud_push/src/lib.rs
@@ -89,7 +89,7 @@ fn fetch<'a, 'b>(
     match event {
         REvent::HashUpdated { key, fields } => unimplemented!(),
         REvent::StringUpdated { key } => fetch_string_delta(key, ctx),
-        REvent::SetUpdated { key } => unimplemented!(),
+        REvent::SetUpdated { key } => fetch_set_delta(key, ctx),
     }
 }
 
@@ -115,6 +115,19 @@ fn fetch_set_delta<'a, 'b>(
         vals: f,
         time: epoch_secs(),
     }))
+}
+
+fn fetch_hash_delta<'a, 'b>(
+    key: &'a str,
+    fields: Vec<String>,
+    ctx: &RedisContext,
+) -> Result<RDelta<'a, 'b>, redis::RedisError> {
+    let found: Vec<Option<String>> = ctx.conn.hget(key, fields)?;
+    Ok(RDelta::UpdateHash {
+        key,
+        fields: unimplemented!(),
+        time: epoch_secs(),
+    })
 }
 
 fn push<E>(data: &RDelta, _pubsub_ctx: &PubSubContext) -> Result<(), E> {

--- a/services/gcloud_push/src/lib.rs
+++ b/services/gcloud_push/src/lib.rs
@@ -12,15 +12,19 @@ extern crate redis_context;
 extern crate serde_derive;
 extern crate yup_oauth2;
 
+pub mod config;
+mod model;
+
 use hyper::net::HttpsConnector;
 use redis_context::RedisContext;
 use redis_delta::RDelta;
 use yup_oauth2::GetToken;
 
+use self::config::PubSubConfig;
+use self::model::{PubSubClient, PubSubContext};
 use self::pubsub::{PublishRequest, PubsubMessage};
 use hyper_native_tls::NativeTlsClient;
 use std::default::Default;
-
 pub fn hello_world(redis_ctx: &RedisContext, pubsub_ctx: &PubSubContext) {
     let mut msg = PubsubMessage::default();
     msg.data = Some("HELLO ANYBODY PLEAES!".to_string());
@@ -60,83 +64,4 @@ pub fn push_recent<E>(
     rdeltas: Vec<RDelta>,
 ) -> Result<(), E> {
     unimplemented!()
-}
-
-/// Note that fq_topic is a fully qualified topic, i.e. `projects/{project_id}/topics/{topic_name}`
-pub struct PubSubContext {
-    pub fq_topic: String,
-    pub client: PubSubClient,
-}
-
-pub type PubSubClient =
-    pubsub::Pubsub<hyper::Client, yup_oauth2::ServiceAccountAccess<hyper::Client>>;
-
-#[derive(Deserialize, Serialize, Debug)]
-pub struct PubSubConfig {
-    pub pubsub_project_id: Option<String>,
-    pub pubsub_topic_name: Option<String>,
-    pub pubsub_secret_file: Option<String>,
-    pub redis_auth: Option<String>,
-    pub redis_host: Option<String>,
-    pub redis_port: Option<u16>,
-    pub redis_namespace: Option<String>,
-}
-
-impl PubSubConfig {
-    pub fn new() -> PubSubConfig {
-        match envy::from_env::<PubSubConfig>() {
-            Ok(config) => config,
-            Err(e) => panic!("Unable to parse config ({})", e),
-        }
-    }
-
-    /// Create an object which holds both a connection to redis
-    /// and a string "namespace" used to prefix all keys.
-    pub fn to_redis_context(&self) -> RedisContext {
-        RedisContext::new(
-            (self.redis_host.clone().unwrap_or("127.0.0.1".to_string())).to_string(),
-            self.redis_port.unwrap_or(6379),
-            self.redis_auth.clone(),
-            self.redis_namespace.clone().unwrap_or("".to_string()),
-        )
-    }
-
-    /// Create a client used to publish to google pub/sub.
-    /// See instructions at https://docs.rs/google-pubsub1_beta2/1.0.8+20181001/google_pubsub1_beta2/
-    pub fn to_pubsub_client(&self) -> PubSubClient {
-        let secret_file = self
-            .pubsub_secret_file
-            .clone()
-            .unwrap_or("secret.json".to_string());
-        let client_secret =
-            yup_oauth2::service_account_key_from_file(&"pubsub-auth.json".to_string()).unwrap();
-        let client =
-            hyper::Client::with_connector(HttpsConnector::new(NativeTlsClient::new().unwrap()));
-        let mut access = yup_oauth2::ServiceAccountAccess::new(client_secret, client);
-
-        println!(
-            "{:?}",
-            access
-                .token(&vec!["https://www.googleapis.com/auth/pubsub"])
-                .unwrap()
-        );
-
-        let client =
-            hyper::Client::with_connector(HttpsConnector::new(NativeTlsClient::new().unwrap()));
-        pubsub::Pubsub::new(client, access)
-    }
-
-    pub fn to_pubsub_context(&self) -> PubSubContext {
-        let project_id = self
-            .pubsub_project_id
-            .clone()
-            .unwrap_or("project".to_string());
-        let topic_name = self
-            .pubsub_topic_name
-            .clone()
-            .unwrap_or("topic".to_string());
-        let fq_topic = format!("projects/{}/topics/{}", project_id, topic_name);
-        let client = self.to_pubsub_client();
-        PubSubContext { fq_topic, client }
-    }
 }

--- a/services/gcloud_push/src/lib.rs
+++ b/services/gcloud_push/src/lib.rs
@@ -18,7 +18,7 @@ mod model;
 use base64;
 
 use redis_context::RedisContext;
-use redis_delta::RDelta;
+use redis_delta::RDeltaEvent;
 
 use self::model::{PubSubClient, PubSubContext};
 use self::pubsub::PublishRequest;
@@ -65,7 +65,7 @@ pub fn clone_the_world(_redis_ctx: &RedisContext, _pubsub_ctx: &PubSubContext) {
 pub fn push_recent<E>(
     _redis_context: &RedisContext,
     _pubsub: &PubSubClient,
-    _rdeltas: Vec<RDelta>,
+    _rdeltas: Vec<RDeltaEvent>,
 ) -> Result<(), E> {
     unimplemented!()
 }

--- a/services/gcloud_push/src/lib.rs
+++ b/services/gcloud_push/src/lib.rs
@@ -33,14 +33,27 @@ use yup_oauth2::{ApplicationSecret, Authenticator, DefaultAuthenticatorDelegate,
 /// - Query each individual sensor of each type
 ///
 /// Push as you satisfy each individual step.
-pub fn clone_the_world(redis_ctx: &RedisContext) {
+pub fn clone_the_world(redis_ctx: &RedisContext, pubsub: &PubSubClient) {
     unimplemented!()
 }
 
 /// pushes some recent data via gcloud pubsub
-pub fn push_recent(redis_context: &RedisContext, rdeltas: Vec<RDelta>) -> Result<()> {
+pub fn push_recent(
+    redis_context: &RedisContext,
+    pubsub: &PubSubClient,
+    rdeltas: Vec<RDelta>,
+) -> Result<()> {
     unimplemented!()
 }
+
+pub type PubSubClient = pubsub::Pubsub<
+    hyper::Client,
+    yup_oauth2::Authenticator<
+        yup_oauth2::DefaultAuthenticatorDelegate,
+        yup_oauth2::MemoryStorage,
+        hyper::Client,
+    >,
+>;
 
 #[derive(Deserialize, Serialize, Debug)]
 pub struct PubSubConfig {
@@ -72,16 +85,7 @@ impl PubSubConfig {
 
     /// Create a client used to publish to google pub/sub.
     /// See instructions at https://docs.rs/google-pubsub1_beta2/1.0.8+20181001/google_pubsub1_beta2/
-    pub fn to_pubsub_client(
-        &self,
-    ) -> pubsub::Pubsub<
-        hyper::Client,
-        yup_oauth2::Authenticator<
-            yup_oauth2::DefaultAuthenticatorDelegate,
-            yup_oauth2::MemoryStorage,
-            hyper::Client,
-        >,
-    > {
+    pub fn to_pubsub_client(&self) -> PubSubClient {
         let secret: ApplicationSecret = Default::default();
         let auth = Authenticator::new(
             &secret,

--- a/services/gcloud_push/src/lib.rs
+++ b/services/gcloud_push/src/lib.rs
@@ -117,7 +117,7 @@ fn fetch_set_delta<'a, 'b>(
     }))
 }
 
-fn fetch_hash_delta<'a, 'b>(
+fn fetch_hash_delta<'a>(
     key: &'a str,
     fields: Vec<String>,
     ctx: &RedisContext,
@@ -125,11 +125,14 @@ fn fetch_hash_delta<'a, 'b>(
     let fields_forever = fields.clone();
     let found: Vec<Option<String>> = ctx.conn.hget(key, fields)?;
     let zipped = fields_forever.iter().zip(found);
-    let rfields = zipped.map(|(f, maybe_v)| maybe_v.map(|v| RField { name: f, val: v }));
+    let rfields: Vec<RField> = zipped
+        .map(|(f, maybe_v)| maybe_v.map(|v| RField { name: f, val: v }))
+        .filter(|maybe| maybe.is_some())
+        .map(|some| some.unwrap()).collect();
 
     Ok(RDelta::UpdateHash {
         key,
-        fields: unimplemented!(),
+        fields: rfields,
         time: epoch_secs(),
     })
 }

--- a/services/gcloud_push/src/lib.rs
+++ b/services/gcloud_push/src/lib.rs
@@ -94,11 +94,15 @@ fn fetch<'a, 'b>(
 }
 
 fn fetch_string<'a, 'b>(
-    key: &str,
+    key: &'a str,
     ctx: &RedisContext,
 ) -> Result<Option<RDelta<'a, 'b>>, redis::RedisError> {
-    let found: Result<Option<String>, _> = ctx.conn.get(key);
-    unimplemented!();
+    let found: Option<String> = ctx.conn.get(key)?;
+    Ok(found.map(|f| RDelta::UpdateString {
+        key,
+        val: f,
+        time: epoch_secs(),
+    }))
 }
 
 fn push<E>(data: &RDelta, _pubsub_ctx: &PubSubContext) -> Result<(), E> {

--- a/services/gcloud_push/src/lib.rs
+++ b/services/gcloud_push/src/lib.rs
@@ -15,17 +15,14 @@ extern crate yup_oauth2;
 pub mod config;
 mod model;
 
-use hyper::net::HttpsConnector;
 use redis_context::RedisContext;
 use redis_delta::RDelta;
-use yup_oauth2::GetToken;
 
-use self::config::PubSubConfig;
 use self::model::{PubSubClient, PubSubContext};
 use self::pubsub::{PublishRequest, PubsubMessage};
-use hyper_native_tls::NativeTlsClient;
 use std::default::Default;
-pub fn hello_world(redis_ctx: &RedisContext, pubsub_ctx: &PubSubContext) {
+
+pub fn hello_world(_redis_ctx: &RedisContext, pubsub_ctx: &PubSubContext) {
     let mut msg = PubsubMessage::default();
     msg.data = Some("HELLO ANYBODY PLEAES!".to_string());
     let req = PublishRequest {
@@ -53,15 +50,15 @@ pub fn hello_world(redis_ctx: &RedisContext, pubsub_ctx: &PubSubContext) {
 /// - Query each individual sensor of each type
 ///
 /// Push as you satisfy each individual step.
-pub fn clone_the_world(redis_ctx: &RedisContext, pubsub_ctx: &PubSubContext) {
+pub fn clone_the_world(_redis_ctx: &RedisContext, _pubsub_ctx: &PubSubContext) {
     unimplemented!()
 }
 
 /// pushes some recent data via gcloud pubsub
 pub fn push_recent<E>(
-    redis_context: &RedisContext,
-    pubsub: &PubSubClient,
-    rdeltas: Vec<RDelta>,
+    _redis_context: &RedisContext,
+    _pubsub: &PubSubClient,
+    _rdeltas: Vec<RDelta>,
 ) -> Result<(), E> {
     unimplemented!()
 }

--- a/services/gcloud_push/src/lib.rs
+++ b/services/gcloud_push/src/lib.rs
@@ -16,15 +16,11 @@ use hyper::net::HttpsConnector;
 use redis_context::RedisContext;
 use redis_delta::RDelta;
 use yup_oauth2::GetToken;
-use self::pubsub::Pubsub;
-use self::pubsub::{Error, Result};
+
 use hyper_native_tls::NativeTlsClient;
 use self::pubsub::{PublishRequest, PubsubMessage};
 use std::default::Default;
-use std::io::Read;
-use yup_oauth2::{
-    Authenticator, ConsoleApplicationSecret, DefaultAuthenticatorDelegate, MemoryStorage,
-};
+
 
 pub fn hello_world(redis_ctx: &RedisContext, pubsub_ctx: &PubSubContext) {
     let mut msg = PubsubMessage::default();
@@ -59,11 +55,11 @@ pub fn clone_the_world(redis_ctx: &RedisContext, pubsub_ctx: &PubSubContext) {
 }
 
 /// pushes some recent data via gcloud pubsub
-pub fn push_recent(
+pub fn push_recent<E>(
     redis_context: &RedisContext,
     pubsub: &PubSubClient,
     rdeltas: Vec<RDelta>,
-) -> Result<()> {
+) -> Result<(), E> {
     unimplemented!()
 }
 

--- a/services/gcloud_push/src/lib.rs
+++ b/services/gcloud_push/src/lib.rs
@@ -60,7 +60,8 @@ pub fn clone_the_world(_redis_ctx: &RedisContext, _pubsub_ctx: &PubSubContext) {
     unimplemented!()
 }
 
-/// pushes some recent data via gcloud pubsub
+/// Publish a vec of redis changes (hash updates, string updates, etc)
+/// to google pubsub system.
 pub fn push_recent<E>(
     _redis_context: &RedisContext,
     _pubsub: &PubSubClient,

--- a/services/gcloud_push/src/lib.rs
+++ b/services/gcloud_push/src/lib.rs
@@ -80,7 +80,9 @@ pub fn push_recent(
         .for_each(|revent| match fetch(revent, redis_ctx) {
             Err(e) => eprintln!("Redis fetch error: {:?}", e),
             Ok(Some(found)) => {
-                push(&found, pubsub_ctx).unwrap_or(eprintln!("Error pushing {:?}", &found))
+                if let Err(e) = push(&found, pubsub_ctx) {
+                    eprintln!("Error pushing {:?}: {:?}", &found, e)
+                }
             }
             _ => (),
         })

--- a/services/gcloud_push/src/lib.rs
+++ b/services/gcloud_push/src/lib.rs
@@ -15,18 +15,24 @@ extern crate yup_oauth2;
 pub mod config;
 mod model;
 
+use base64;
+
 use redis_context::RedisContext;
 use redis_delta::RDelta;
 
 use self::model::{PubSubClient, PubSubContext};
-use self::pubsub::{PublishRequest, PubsubMessage};
+use self::pubsub::{PublishRequest};
 use std::default::Default;
 
 pub fn hello_world(_redis_ctx: &RedisContext, pubsub_ctx: &PubSubContext) {
-    let mut msg = PubsubMessage::default();
-    msg.data = Some("HELLO ANYBODY PLEAES!".to_string());
+    let message = google_pubsub1::PubsubMessage {
+        // Base64 encoded!
+        data: Some(base64::encode("HELLO ANYONE!".as_bytes())),
+        ..Default::default()
+    };
+
     let req = PublishRequest {
-        messages: Some(vec![msg]),
+        messages: Some(vec![message]),
     };
 
     println!("Publishing to {}", &pubsub_ctx.fq_topic);

--- a/services/gcloud_push/src/lib.rs
+++ b/services/gcloud_push/src/lib.rs
@@ -21,7 +21,7 @@ use redis_context::RedisContext;
 use redis_delta::RDelta;
 
 use self::model::{PubSubClient, PubSubContext};
-use self::pubsub::{PublishRequest};
+use self::pubsub::PublishRequest;
 use std::default::Default;
 
 pub fn hello_world(_redis_ctx: &RedisContext, pubsub_ctx: &PubSubContext) {

--- a/services/gcloud_push/src/lib.rs
+++ b/services/gcloud_push/src/lib.rs
@@ -149,9 +149,24 @@ fn fetch_hash_delta<'a>(
     })
 }
 
-struct PushErr;
-fn push(data: &RDelta, _pubsub_ctx: &PubSubContext) -> Result<(), PushErr> {
-    unimplemented!()
+fn push(data: &RDelta, pubsub_ctx: &PubSubContext) -> Result<(), pubsub::Error> {
+    let message = google_pubsub1::PubsubMessage {
+        // Base64 encoded!
+        data: Some(base64::encode("HELLO ANYONE!".as_bytes())),
+        ..Default::default()
+    };
+
+    let req = PublishRequest {
+        messages: Some(vec![message]),
+    };
+
+    println!("Publishing to {}", &pubsub_ctx.fq_topic);
+    pubsub_ctx
+        .client
+        .projects()
+        .topics_publish(req, &pubsub_ctx.fq_topic)
+        .doit()
+        .map(|_r| ())
 }
 
 fn epoch_secs() -> u64 {

--- a/services/gcloud_push/src/model.rs
+++ b/services/gcloud_push/src/model.rs
@@ -1,0 +1,8 @@
+/// Note that fq_topic is a fully qualified topic, i.e. `projects/{project_id}/topics/{topic_name}`
+pub struct PubSubContext {
+    pub fq_topic: String,
+    pub client: PubSubClient,
+}
+
+pub type PubSubClient =
+    google_pubsub1::Pubsub<hyper::Client, yup_oauth2::ServiceAccountAccess<hyper::Client>>;

--- a/services/gcloud_push/src/model.rs
+++ b/services/gcloud_push/src/model.rs
@@ -1,3 +1,12 @@
+use redis_delta::RDelta;
+
+#[derive(Deserialize, Serialize, Debug)]
+pub struct RUpdate<'a, 'b> {
+    #[serde(borrow)]
+    rdelta: RDelta<'a, 'b>,
+    time: u64,
+}
+
 /// Note that fq_topic is a fully qualified topic, i.e. `projects/{project_id}/topics/{topic_name}`
 pub struct PubSubContext {
     pub fq_topic: String,

--- a/services/gcloud_push/src/model.rs
+++ b/services/gcloud_push/src/model.rs
@@ -4,5 +4,12 @@ pub struct PubSubContext {
     pub client: PubSubClient,
 }
 
+/// Note that this pub sub client specifically uses the
+/// "service account access" credentials strategy, and
+/// *not* an OAuth2 credentials strategy.
+///
+/// google_pubsub1::PubSub is capable of supporting an
+/// OAuth credentials strategy, but we don't need it
+/// here, for this simple backend application.
 pub type PubSubClient =
     google_pubsub1::Pubsub<hyper::Client, yup_oauth2::ServiceAccountAccess<hyper::Client>>;

--- a/services/gcloud_push/src/model.rs
+++ b/services/gcloud_push/src/model.rs
@@ -1,12 +1,3 @@
-use redis_delta::RDelta;
-
-#[derive(Deserialize, Serialize, Debug)]
-pub struct RUpdate<'a, 'b> {
-    #[serde(borrow)]
-    rdelta: RDelta<'a, 'b>,
-    time: u64,
-}
-
 /// Note that fq_topic is a fully qualified topic, i.e. `projects/{project_id}/topics/{topic_name}`
 pub struct PubSubContext {
     pub fq_topic: String,

--- a/services/redis_delta/Cargo.toml
+++ b/services/redis_delta/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redis_delta"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Terkwood <metaterkhorn@gmail.com>"]
 edition = "2018"
 

--- a/services/redis_delta/src/lib.rs
+++ b/services/redis_delta/src/lib.rs
@@ -105,7 +105,7 @@ pub struct RField<'a> {
 /// it *does* include a list of fields which were changed.
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "snake_case")]
-pub enum RDeltaEvent {
+pub enum REvent {
     SetUpdated { key: String },
     HashUpdated { key: String, fields: Vec<String> },
     StringUpdated { key: String },
@@ -203,9 +203,10 @@ mod rdelta_test {
         let set_friend = &RDelta::UpdateSet {
             key: &Key::AllSensorTypes { ns: ns() }.to_string(),
             vals: vec![id_str()],
+            time: 0,
         };
         assert_eq!(serde_json::to_string(set_friend).unwrap(),
-        r#"{"update_set":{"key":"prawnspace/sensors","vals":["123e4567-e89b-12d3-a456-426655440000"]}}"#);
+        r#"{"update_set":{"key":"prawnspace/sensors","vals":["123e4567-e89b-12d3-a456-426655440000"],"time":0}}"#);
     }
 
     #[test]
@@ -222,26 +223,28 @@ mod rdelta_test {
             }
             .to_string(),
             fields,
+            time: 0,
         };
 
         assert_eq!(serde_json::to_string(new_potatoes).unwrap(),
-         r#"{"update_hash":{"key":"prawnspace/sensors/temp/123e4567-e89b-12d3-a456-426655440000","fields":[{"name":"temp_f","val":"82.31"}]}}"#);
+         r#"{"update_hash":{"key":"prawnspace/sensors/temp/123e4567-e89b-12d3-a456-426655440000","fields":[{"name":"temp_f","val":"82.31"}],"time":0}}"#);
     }
 
     #[test]
     fn update_string_ser() {
         let uk = &Key::AllTanks { ns: ns() }.to_string();
         let uv = "2";
-        let update = &RDelta::UpdateString { key: uk, val: uv };
+        let update = &RDelta::UpdateString { key: uk, val: uv, time: 0 };
 
-        let expected = &r#"{"update_string":{"key":"prawnspace/tanks","val":"2"}}"#;
+        let expected = &r#"{"update_string":{"key":"prawnspace/tanks","val":"2","time":0}}"#;
         assert_eq!(serde_json::to_string(update).unwrap(), expected.to_string());
 
         let deser: RDelta = serde_json::from_str(expected).unwrap();
         match deser {
-            RDelta::UpdateString { key, val } => {
+            RDelta::UpdateString { key, val, time } => {
                 assert_eq!(key, *uk);
                 assert_eq!(val, uv);
+                assert_eq!(time, 0);
             }
             _ => assert!(false),
         }

--- a/services/redis_delta/src/lib.rs
+++ b/services/redis_delta/src/lib.rs
@@ -71,7 +71,7 @@ impl<'a, 'b> Key<'a, 'b> {
 /// for when this record was retrieved.
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "snake_case")]
-pub enum RDelta<'a, 'b> {
+pub enum RDelta<'a> {
     UpdateSet {
         #[serde(borrow)]
         key: &'a str,
@@ -80,8 +80,7 @@ pub enum RDelta<'a, 'b> {
     },
     UpdateHash {
         key: &'a str,
-        #[serde(borrow)]
-        fields: Vec<RField<'b>>,
+        fields: Vec<RField>,
         time: u64,
     },
     UpdateString {
@@ -93,8 +92,8 @@ pub enum RDelta<'a, 'b> {
 
 /// A field which is stored in Redis.
 #[derive(Serialize, Deserialize, Debug)]
-pub struct RField<'a> {
-    pub name: &'a str,
+pub struct RField {
+    pub name: String,
     pub val: String,
 }
 
@@ -183,12 +182,12 @@ mod rdelta_test {
         Namespace("prawnspace")
     }
 
-    fn id_str() -> &'static str {
-        "123e4567-e89b-12d3-a456-426655440000"
+    fn id_str() -> String {
+        "123e4567-e89b-12d3-a456-426655440000".to_string()
     }
 
     fn id() -> Uuid {
-        Uuid::parse_str(id_str()).unwrap()
+        Uuid::parse_str(&id_str()).unwrap()
     }
 
     #[test]
@@ -211,8 +210,8 @@ mod rdelta_test {
     #[test]
     fn update_hash_ser() {
         let fields: Vec<RField> = vec![RField {
-            name: "temp_f",
-            val: "82.31",
+            name: "temp_f".to_string(),
+            val: "82.31".to_string(),
         }];
         let new_potatoes = &RDelta::UpdateHash {
             key: &Key::Sensor {

--- a/services/redis_delta/src/lib.rs
+++ b/services/redis_delta/src/lib.rs
@@ -5,7 +5,6 @@ extern crate serde_json;
 extern crate serde_derive;
 
 use uuid::Uuid;
-
 /// This enum represents various keys which should
 /// exist in our database.  They each have a namespace
 /// parameter `ns`, which indicates a common "root"
@@ -91,30 +90,6 @@ pub enum RDelta<'a, 'b> {
         time: u64,
     },
 }
-
-
-// TODO               TODO               TODO               TODO               TODO               
-// TODO               TODO               TODO               TODO               TODO               
-// TODO               TODO               TODO               TODO               TODO               
-// TODO
-// TODO
-// TODO
-//              Implement FROM for RDELTAs for String, Hash, Set!!!            
-// TODO
-// TODO
-// TODO
-// TODO               TODO               TODO               TODO               TODO               
-// TODO               TODO               TODO               TODO               TODO               
-// TODO               TODO               TODO               TODO               TODO               
-
-
-
-
-
-
-
-
-
 
 /// A field which is stored in Redis.
 #[derive(Serialize, Deserialize, Debug)]
@@ -258,7 +233,11 @@ mod rdelta_test {
     fn update_string_ser() {
         let uk = &Key::AllTanks { ns: ns() }.to_string();
         let uv = "2";
-        let update = &RDelta::UpdateString { key: uk, val: uv, time: 0 };
+        let update = &RDelta::UpdateString {
+            key: uk,
+            val: uv,
+            time: 0,
+        };
 
         let expected = &r#"{"update_string":{"key":"prawnspace/tanks","val":"2","time":0}}"#;
         assert_eq!(serde_json::to_string(update).unwrap(), expected.to_string());

--- a/services/redis_delta/src/lib.rs
+++ b/services/redis_delta/src/lib.rs
@@ -75,12 +75,12 @@ pub enum RDelta<'a, 'b> {
     UpdateSet {
         #[serde(borrow)]
         key: &'a str,
-        #[serde(borrow)]
-        vals: Vec<&'b str>,
+        vals: Vec<String>,
         time: u64,
     },
     UpdateHash {
         key: &'a str,
+        #[serde(borrow)]
         fields: Vec<RField<'b>>,
         time: u64,
     },

--- a/services/redis_delta/src/lib.rs
+++ b/services/redis_delta/src/lib.rs
@@ -70,7 +70,7 @@ impl<'a, 'b> Key<'a, 'b> {
 /// of key/value used by the prawnalith.
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "snake_case")]
-enum RDelta<'a, 'b> {
+pub enum RDelta<'a, 'b> {
     UpdateSet {
         #[serde(borrow)]
         key: &'a str,

--- a/services/redis_delta/src/lib.rs
+++ b/services/redis_delta/src/lib.rs
@@ -68,6 +68,8 @@ impl<'a, 'b> Key<'a, 'b> {
 /// Represents a change to a value in Redis.
 /// Currently only supports the minimum combinations
 /// of key/value used by the prawnalith.
+/// The `time` field represents epoch millis in UTC
+/// for when this record was retrieved.
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "snake_case")]
 pub enum RDelta<'a, 'b> {
@@ -76,14 +78,17 @@ pub enum RDelta<'a, 'b> {
         key: &'a str,
         #[serde(borrow)]
         vals: Vec<&'b str>,
+        time: u64,
     },
     UpdateHash {
         key: &'a str,
         fields: Vec<RField<'b>>,
+        time: u64,
     },
     UpdateString {
         key: &'a str,
         val: &'b str,
+        time: u64,
     },
 }
 

--- a/services/redis_delta/src/lib.rs
+++ b/services/redis_delta/src/lib.rs
@@ -68,7 +68,7 @@ impl<'a, 'b> Key<'a, 'b> {
 /// Represents a change to a value in Redis.
 /// Currently only supports the minimum combinations
 /// of key/value used by the prawnalith.
-/// The `time` field represents epoch millis in UTC
+/// The `time` field represents epoch secs in UTC
 /// for when this record was retrieved.
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "snake_case")]
@@ -91,6 +91,30 @@ pub enum RDelta<'a, 'b> {
         time: u64,
     },
 }
+
+
+// TODO               TODO               TODO               TODO               TODO               
+// TODO               TODO               TODO               TODO               TODO               
+// TODO               TODO               TODO               TODO               TODO               
+// TODO
+// TODO
+// TODO
+//              Implement FROM for RDELTAs for String, Hash, Set!!!            
+// TODO
+// TODO
+// TODO
+// TODO               TODO               TODO               TODO               TODO               
+// TODO               TODO               TODO               TODO               TODO               
+// TODO               TODO               TODO               TODO               TODO               
+
+
+
+
+
+
+
+
+
 
 /// A field which is stored in Redis.
 #[derive(Serialize, Deserialize, Debug)]

--- a/services/redis_delta/src/lib.rs
+++ b/services/redis_delta/src/lib.rs
@@ -86,7 +86,7 @@ pub enum RDelta<'a, 'b> {
     },
     UpdateString {
         key: &'a str,
-        val: &'b str,
+        val: String,
         time: u64,
     },
 }
@@ -235,7 +235,7 @@ mod rdelta_test {
         let uv = "2";
         let update = &RDelta::UpdateString {
             key: uk,
-            val: uv,
+            val: uv.to_string(),
             time: 0,
         };
 
@@ -246,7 +246,7 @@ mod rdelta_test {
         match deser {
             RDelta::UpdateString { key, val, time } => {
                 assert_eq!(key, *uk);
-                assert_eq!(val, uv);
+                assert_eq!(val, uv.to_string());
                 assert_eq!(time, 0);
             }
             _ => assert!(false),

--- a/services/redis_delta/src/lib.rs
+++ b/services/redis_delta/src/lib.rs
@@ -94,8 +94,8 @@ pub enum RDelta<'a, 'b> {
 /// A field which is stored in Redis.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct RField<'a> {
-    name: &'a str,
-    val: &'a str,
+    pub name: &'a str,
+    pub val: String,
 }
 
 /// Represents a message that lets you know that a specific

--- a/services/sensor_tracker/Cargo.lock
+++ b/services/sensor_tracker/Cargo.lock
@@ -428,7 +428,7 @@ dependencies = [
 
 [[package]]
 name = "redis_delta"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -511,14 +511,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "sensor_tracker"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "dotenv 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "envy 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "paho-mqtt 0.4.0 (git+https://github.com/Terkwood/paho.mqtt.rust.git?rev=1b72f84)",
  "redis 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "redis_context 0.1.0",
- "redis_delta 0.1.0",
+ "redis_delta 0.1.1",
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/services/sensor_tracker/Cargo.toml
+++ b/services/sensor_tracker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sensor_tracker"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Terkwood <metaterkhorn@gmail.com>"]
 edition = "2018"
 


### PR DESCRIPTION
Implements a basic application which can read redis values based on a list of keys, and push them to google pub sub.

This will be used to keep a cloud redis instance in sync with the local redis instance which tracks our temp & pH values.

This is a partial implementation.  The full implementation will be triggered by messages on redis's pub-sub channel.  