### PR TITLE
Pond service: provide tank statuses when queried

### DIFF
--- a/cloud_images/pond/Cargo.toml
+++ b/cloud_images/pond/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pond"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Terkwood <metaterkhorn@gmail.com>"]
 edition = "2018"
 
@@ -9,12 +9,14 @@ base64 = "0.10"
 dotenv = "0.13"
 envy = "0.3"
 frank_jwt = "3.0"
+hashbrown = "0.1"
 lazy_static = "1.2"
 openssl = "0.10"
 redis = "0.9"
+redis_delta = { git = "https://github.com/Terkwood/prawnalith/", branch = "unstable" }
 regex = "1"
 reqwest = "0.9"
-rocket = { version = "0.4.0-rc.1", features = ["tls"] }
+rocket = { version = "0.4.0-rc.1", features = [ "tls" ] }
 serde = "1"
 serde_derive = "1"
 serde_json = "1"
@@ -22,4 +24,5 @@ serde_json = "1"
 [dependencies.rocket_contrib]
 version = "0.4.0-rc.1"
 default-features = false
-features = ["redis_pool"]
+features = [ "json", "redis_pool" ]
+

--- a/cloud_images/pond/src/lib.rs
+++ b/cloud_images/pond/src/lib.rs
@@ -1,8 +1,10 @@
 #![feature(proc_macro_hygiene, decl_macro, bind_by_move_pattern_guards)]
 extern crate base64;
 extern crate frank_jwt;
+extern crate hashbrown;
 #[macro_use]
 extern crate lazy_static;
+extern crate redis_delta;
 #[macro_use]
 extern crate rocket;
 #[macro_use]
@@ -18,4 +20,5 @@ pub mod claims;
 pub mod config;
 pub mod key_pairs;
 mod redis_conn;
+mod tanks;
 pub mod web;

--- a/cloud_images/pond/src/tanks.rs
+++ b/cloud_images/pond/src/tanks.rs
@@ -1,0 +1,140 @@
+use crate::redis_conn::RedisDbConn;
+use hashbrown::HashMap;
+use redis_delta::{Key, Namespace};
+use rocket_contrib::databases::redis::Commands;
+
+/// A struct to hold data returned by the HTTP request
+/// for tanks' temp & ph info.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Tank {
+    pub id: u16,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub temp_f: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub temp_c: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub temp_update_time: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub temp_update_count: Option<u32>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ph: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ph_mv: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ph_update_time: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ph_update_count: Option<u32>,
+}
+
+impl Tank {
+    pub fn from_fields(id: u16, fields: &HashMap<&str, String>) -> Tank {
+        let (temp_f, temp_c) = match (
+            parse_maybe::<f32>(fields.get("temp_f")),
+            parse_maybe::<f32>(fields.get("temp_c")),
+        ) {
+            (Some(f), Some(c)) => (Some(f), Some(c)),
+            (Some(f), _) => (Some(f), Some(f_to_c(f))),
+            (_, Some(c)) => (Some(c_to_f(c)), Some(c)),
+            (_, _) => (None, None),
+        };
+
+        Tank {
+            id,
+            name: parse_maybe::<String>(fields.get("name")),
+            temp_f,
+            temp_c,
+            temp_update_time: parse_maybe::<u64>(fields.get("temp_update_time")),
+            temp_update_count: parse_maybe::<u32>(fields.get("temp_update_count")),
+            ph: parse_maybe::<f32>(fields.get("ph")),
+            ph_mv: parse_maybe::<f32>(fields.get("ph_mv")),
+            ph_update_time: parse_maybe::<u64>(fields.get("ph_update_time")),
+            ph_update_count: parse_maybe::<u32>(fields.get("ph_update_count")),
+        }
+    }
+}
+
+/// Fetch the status of all tanks from Redis.
+pub fn fetch_all(conn: RedisDbConn, namespace: &str) -> Result<Vec<Tank>, redis::RedisError> {
+    // figure out how many tanks you need to query
+    let num_tanks = fetch_num_tanks(&conn, namespace)?;
+
+    // query each tank for its status
+    let mut result: Vec<Tank> = vec![];
+    for id in 1..=num_tanks {
+        if let Some(t_status) = fetch_tank_status(id, &conn, namespace)? {
+            result.push(t_status);
+        }
+    }
+
+    Ok(result)
+}
+
+fn fetch_num_tanks(conn: &RedisDbConn, namespace: &str) -> Result<u16, redis::RedisError> {
+    let key = Key::AllTanks {
+        ns: Namespace(namespace),
+    }
+    .to_string();
+    conn.0.get(key)
+}
+const TANK_FIELDS: &[&'static str] = &[
+    "name",
+    "temp_f",
+    "temp_c",
+    "temp_update_time",
+    "temp_update_count",
+    "ph",
+    "ph_mv",
+    "ph_update_time",
+    "ph_update_count",
+];
+
+/// Fetch the status of an individual tank from Redis
+fn fetch_tank_status(
+    id: u16,
+    conn: &RedisDbConn,
+    namespace: &str,
+) -> Result<Option<Tank>, redis::RedisError> {
+    let key = Key::Tank {
+        ns: Namespace(namespace),
+        id,
+    }
+    .to_string();
+
+    let data: Vec<Option<String>> = conn.0.hget(&key, TANK_FIELDS)?;
+
+    let no_results: bool = data.iter().all(|maybe| maybe.is_none());
+
+    Ok(if no_results {
+        None
+    } else {
+        Some({
+            let mut with_field_names: HashMap<&str, String> = hashbrown::HashMap::new();
+
+            let i: Vec<(&str, Option<String>)> = TANK_FIELDS.iter().map(|s| *s).zip(data).collect();
+            for (field, maybe_val) in i {
+                if let Some(val) = maybe_val {
+                    with_field_names.insert(field, val);
+                }
+            }
+
+            Tank::from_fields(id, &with_field_names)
+        })
+    })
+}
+
+fn f_to_c(f: f32) -> f32 {
+    (f - 32f32) * 5f32 / 9f32
+}
+fn c_to_f(c: f32) -> f32 {
+    (c * 9f32 / 5f32) + 32f32
+}
+
+fn parse_maybe<T>(maybe: Option<&String>) -> Option<T>
+where
+    T: std::str::FromStr,
+{
+    maybe.and_then(|s| s.parse::<T>().ok())
+}

--- a/cloud_images/pond/src/web.rs
+++ b/cloud_images/pond/src/web.rs
@@ -3,15 +3,23 @@ use crate::authorization::authorize;
 use crate::config::Config;
 use crate::key_pairs;
 use crate::redis_conn::*;
+use crate::tanks;
 use rocket::http::Status;
 use rocket::request::{self, FromRequest, Request};
 use rocket::{Outcome, State};
+use rocket_contrib::json::Json;
 
 /// This route requires that you authenticate using
 /// a Firebase-signed JWT.
+/// If redis blows up, the error will be logged using Debug,
+/// and an opaque 500 status message will be returned to the caller.
 #[get("/tanks")]
-pub fn tanks(_user: AuthorizedUser) -> &'static str {
-    "🏖 Welcome, authorized user! 🦐"
+pub fn tanks(
+    _user: AuthorizedUser,
+    conn: RedisDbConn,
+    config: State<Config>,
+) -> Result<Json<Vec<tanks::Tank>>, redis::RedisError> {
+    Ok(Json(tanks::fetch_all(conn, &config.redis_namespace)?))
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
Implements #45 

```
curl -k -H "Authorization: Bearer $FIREBASE_JWT" https://$FIREBASE_HOST/tanks | python -m json.tool
```  

```
[
    {
        "id": 1,
        "name": "The Mothership",
        "ph": 7.72,
        "ph_mv": 461.05,
        "ph_update_count": 2454127,
        "ph_update_time": 1542744006,
        "temp_c": 27.56,
        "temp_f": 81.61,
        "temp_update_count": 2535781,
        "temp_update_time": 1542744006
    },
    {
        "id": 2,
        "name": "The Pond",
        "temp_c": 24.62,
        "temp_f": 76.32,
        "temp_update_count": 191511,
        "temp_update_time": 1542744003
    }
]
```