### PR TITLE
redis_aggregator: sign published messages with hmac sha256

### DIFF
--- a/services/redis_aggregator/Cargo.lock
+++ b/services/redis_aggregator/Cargo.lock
@@ -180,7 +180,7 @@ dependencies = [
  "arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-utils 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -204,7 +204,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "failure 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -271,6 +271,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "futures"
 version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "gcc"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -392,11 +397,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "lazy_static"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "lazycell"
@@ -509,7 +511,7 @@ name = "native-tls"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl 0.10.15 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -564,7 +566,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl-sys 0.9.39 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -577,7 +579,7 @@ dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl-sys 0.9.39 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -716,7 +718,7 @@ dependencies = [
 
 [[package]]
 name = "redis_aggregator"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "base64 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-channel 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -728,7 +730,8 @@ dependencies = [
  "hyper-native-tls 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "redis 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "redis_context 0.1.0 (git+https://github.com/Terkwood/prawnalith/?branch=unstable)",
- "redis_delta 0.1.2",
+ "redis_delta 0.2.0",
+ "rust-crypto 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -747,7 +750,7 @@ dependencies = [
 
 [[package]]
 name = "redis_delta"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -789,6 +792,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-crypto"
+version = "0.2.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "gcc 0.3.55 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -821,7 +836,7 @@ name = "schannel"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -979,7 +994,7 @@ name = "thread_local"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1027,7 +1042,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "crossbeam-utils 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1259,6 +1274,7 @@ dependencies = [
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 "checksum futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)" = "49e7653e374fe0d0c12de4250f0bdb60680b8c80eed558c5c7538eec9c89e21b"
+"checksum gcc 0.3.55 (registry+https://github.com/rust-lang/crates.io-index)" = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
 "checksum google-pubsub1 1.0.8+20181001 (registry+https://github.com/rust-lang/crates.io-index)" = "87c4bd8871ca2f700519861760bbbd639ccf4b4f33bae20d905c357542368ffa"
 "checksum hashbrown 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "18cb46d7cc72edf1580c1e75c1988715c52d5efdc9dad51539aa88f381f634af"
 "checksum httparse 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e8734b0cfd3bc3e101ec59100e101c2eecd19282202e87808b3037b442777a83"
@@ -1272,7 +1288,7 @@ dependencies = [
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
 "checksum lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
-"checksum lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ca488b89a5657b0a2ecd45b95609b3e848cf1755da332a0da46e2b2b1cb371a7"
+"checksum lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a374c89b9db55895453a74c1e38861d9deec0b01b405a82516e9d5de4820dea1"
 "checksum lazycell 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ddba4c30a78328befecec92fc94970e53b3ae385827d28620f0f5bb2493081e0"
 "checksum libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)" = "76e3a3ef172f1a0b9a9ff0dd1491ae5e6c948b94479a3021819ba7d860c8645d"
 "checksum lock_api 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "775751a3e69bde4df9b38dd00a1b5d6ac13791e4223d4a0506577f0dd27cfb7a"
@@ -1313,6 +1329,7 @@ dependencies = [
 "checksum regex 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "2069749032ea3ec200ca51e4a31df41759190a88edca0d2d86ee8bedf7073341"
 "checksum regex-syntax 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "747ba3b235651f6e2f67dfa8bcdcd073ddb7c243cb21c442fc12395dfcac212d"
 "checksum remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5"
+"checksum rust-crypto 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)" = "f76d05d3993fd5f4af9434e8e436db163a12a9d40e1a58a726f27a01dfd12a2a"
 "checksum rustc-demangle 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "bcfe5b13211b4d78e5c2cadfebd7769197d95c639c35a50057eb4c05de811395"
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"

--- a/services/redis_aggregator/Cargo.lock
+++ b/services/redis_aggregator/Cargo.lock
@@ -730,7 +730,7 @@ dependencies = [
  "hyper-native-tls 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "redis 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "redis_context 0.1.0 (git+https://github.com/Terkwood/prawnalith/?branch=unstable)",
- "redis_delta 0.2.0",
+ "redis_delta 0.1.2",
  "rust-crypto 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -750,7 +750,7 @@ dependencies = [
 
 [[package]]
 name = "redis_delta"
-version = "0.2.0"
+version = "0.1.2"
 dependencies = [
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/services/redis_aggregator/Cargo.toml
+++ b/services/redis_aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redis_aggregator"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Terkwood <metaterkhorn@gmail.com>"]
 edition = "2018"
 
@@ -13,6 +13,7 @@ hashbrown = "0.1"
 redis = "0.9"
 redis_context = { git = "https://github.com/Terkwood/prawnalith/", branch = "unstable" }
 redis_delta = { path = "../redis_delta" } #FIXME use github ref
+rust-crypto = "^0.2"
 serde = "^1.0"
 serde_derive = "^1.0"
 serde_json = "^1.0"

--- a/services/redis_aggregator/examples/clone.rs
+++ b/services/redis_aggregator/examples/clone.rs
@@ -14,10 +14,7 @@ fn main() {
 
     let config = PubSubConfig::new();
 
-    let redis_ctx = &config.to_redis_context();
-    let pubsub_ctx = &config.to_pubsub_context();
-
     println!("Wherein We Clone the World");
 
-    clone_the_world(redis_ctx, pubsub_ctx).unwrap();
+    clone_the_world(&config);
 }

--- a/services/redis_aggregator/examples/fetch_push.rs
+++ b/services/redis_aggregator/examples/fetch_push.rs
@@ -6,7 +6,7 @@ extern crate redis_context;
 extern crate uuid;
 
 use redis_aggregator::config::PubSubConfig;
-use redis_aggregator::push_recent;
+use redis_aggregator::publish_recent;
 use redis_delta::REvent;
 
 fn main() {
@@ -17,7 +17,7 @@ fn main() {
     let redis_ctx = &config.to_redis_context();
     let pubsub_ctx = &config.to_pubsub_context();
 
-    push_recent(
+    publish_recent(
         redis_ctx,
         pubsub_ctx,
         vec![REvent::StringUpdated {
@@ -26,7 +26,7 @@ fn main() {
     )
     .unwrap();
 
-    push_recent(
+    publish_recent(
         redis_ctx,
         pubsub_ctx,
         vec![REvent::HashUpdated {

--- a/services/redis_aggregator/src/config.rs
+++ b/services/redis_aggregator/src/config.rs
@@ -5,7 +5,7 @@ use yup_oauth2::GetToken;
 use crate::pubsub::{PubSubClient, PubSubContext};
 use hyper_native_tls::NativeTlsClient;
 
-#[derive(Deserialize, Serialize, Debug)]
+#[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct PubSubConfig {
     pub pubsub_publish_interval_secs: Option<u64>,
     pub pubsub_project_id: Option<String>,
@@ -16,6 +16,7 @@ pub struct PubSubConfig {
     pub redis_port: Option<u16>,
     pub redis_namespace: Option<String>,
     pub redis_source_topic_name: String,
+    pub signing_secret: String,
 }
 
 impl PubSubConfig {
@@ -81,6 +82,11 @@ impl PubSubConfig {
         let topic_name = self.pubsub_dest_topic_name.clone();
         let fq_topic = format!("projects/{}/topics/{}", project_id, topic_name);
         let client = self.to_pubsub_client();
-        PubSubContext { fq_topic, client }
+        let signing_secret = self.signing_secret.as_bytes().to_owned();
+        PubSubContext {
+            fq_topic,
+            client,
+            signing_secret,
+        }
     }
 }

--- a/services/redis_aggregator/src/lib.rs
+++ b/services/redis_aggregator/src/lib.rs
@@ -278,8 +278,6 @@ fn publish(data: Vec<RDelta>, pubsub_ctx: &PubSubContext) -> Result<(), google_p
     for delta in data {
         let json = serde_json::to_string(&delta).unwrap();
 
-        println!("    message: {}", json);
-
         let message_base64 = base64::encode(json.as_bytes());
 
         let mut attrs: std::collections::HashMap<String, String> = std::collections::HashMap::new();

--- a/services/redis_aggregator/src/pubsub.rs
+++ b/services/redis_aggregator/src/pubsub.rs
@@ -2,6 +2,7 @@
 pub struct PubSubContext {
     pub fq_topic: String,
     pub client: PubSubClient,
+    pub signing_secret: Vec<u8>,
 }
 
 /// Note that this pub sub client specifically uses the

--- a/services/redis_delta/Cargo.toml
+++ b/services/redis_delta/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redis_delta"
-version = "0.2.0"
+version = "0.1.2"
 authors = ["Terkwood <metaterkhorn@gmail.com>"]
 edition = "2018"
 

--- a/services/redis_delta/Cargo.toml
+++ b/services/redis_delta/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redis_delta"
-version = "0.1.2"
+version = "0.2.0"
 authors = ["Terkwood <metaterkhorn@gmail.com>"]
 edition = "2018"
 


### PR DESCRIPTION
Allows the redis aggregator to sign its messages, providing verification that it's the sender it claims to be.  Partial completion of #60 