### PR TITLE
Get rid of unwrap() in sensor_tracker

### DIFF
--- a/services/sensor_tracker/Cargo.lock
+++ b/services/sensor_tracker/Cargo.lock
@@ -512,7 +512,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "sensor_tracker"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "dotenv 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "envy 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/services/sensor_tracker/Cargo.toml
+++ b/services/sensor_tracker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sensor_tracker"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["Terkwood <metaterkhorn@gmail.com>"]
 edition = "2018"
 

--- a/services/sensor_tracker/src/logic.rs
+++ b/services/sensor_tracker/src/logic.rs
@@ -16,12 +16,13 @@ pub fn receive_updates(
                     let ext_device_id: &str = &sensor_message.device_id;
 
                     sensor_message.measurements().iter().for_each(|measure| {
-                        let delta_events = predis::update(redis_ctx, &measure, ext_device_id);
-
-                        // emit all changed keys & hash field names to redis
-                        // on the appropriate redis pub/sub topic.
-                        // these will be processed later by the gcloud_push utility
-                        predis::publish_updates(redis_ctx, delta_event_topic, delta_events)
+                        if let Ok(delta_events) = predis::update(redis_ctx, &measure, ext_device_id)
+                        {
+                            // emit all changed keys & hash field names to redis
+                            // on the appropriate redis pub/sub topic.
+                            // these will be processed later by the gcloud_push utility
+                            predis::publish_updates(redis_ctx, delta_event_topic, delta_events)
+                        }
                     });
                 }
             }


### PR DESCRIPTION
We've seen UTF8 errors reported a couple times, which causes sensor tracker to crash.  This changeset removes rust `unwrap()` functions from sensor tracker and just ignores any strings which would cause such a crash.